### PR TITLE
Now Using Customization Point Objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ debug/*
 release/*
 
 .vscode/*
+
+CMakeLists.txt.user

--- a/source/json_deserializer.h
+++ b/source/json_deserializer.h
@@ -31,18 +31,22 @@ struct from_json_functor
 } // namespace detail
 
 // Template variables are required to have external linkage per the Standard.
-template <typename DataType> constexpr DataType external_linkage{};
+template <typename DataType> constexpr DataType apply_external_linkage{};
 
 namespace
 {
-// The anonymous namespace is needed to keep the reference "itself from being multiply defined."
-// Each reference will have internal linkage, but "the references all refer to the same object,"
-// and "since every mention [...] in all translation units refer to the same entity, there is no
-// ODR violation. Source: Suggested Design for Customization Points
+// Variables declared at global scope will have external linkage, so we'll need to use an anonymous
+// namespace to keep the enclosed reference "itself from being multiply defined." This works
+// because anonymous namespaces behave as if a unique identifier were chosen for each translation
+// unit in which it appears. As a result, the reference has internal linkage. However, since the
+// reference below refers to a variable template (which is required to have external linkage), "all
+// translation units [will] refer to the same entity," and therefore "there is no ODR violation."
+//
+// Source: Suggested Design for Customization Points
 // [http://ericniebler.github.io/std/wg21/D4381.html]
 //
-// @note Use an inline variable when upgrading to C++17.
-constexpr const auto& from_json = external_linkage<detail::from_json_functor>;
+// @note Use an `inline constexpr` variable when upgrading to C++17.
+constexpr const auto& from_json = apply_external_linkage<detail::from_json_functor>;
 }
 
 struct default_insertion_policy

--- a/source/json_fwd.h
+++ b/source/json_fwd.h
@@ -4,6 +4,7 @@
 #include <filesystem>
 #endif
 
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -20,6 +21,8 @@
 namespace json_utils
 {
 namespace serializer
+{
+namespace detail
 {
 template <typename OutputStreamType, typename SourceEncodingType, typename TargetEncodingType>
 void to_json(
@@ -62,7 +65,7 @@ void to_json(
 template <typename OutputStreamType, typename SourceEncodingType, typename TargetEncodingType>
 auto to_json(
     rapidjson::Writer<OutputStreamType, SourceEncodingType, TargetEncodingType>& writer,
-    const char* const data) ->
+    const char* data) ->
     typename std::enable_if<std::is_same<
         char, typename rapidjson::Writer<
                   OutputStreamType, SourceEncodingType, TargetEncodingType>::Ch>::value>::type;
@@ -70,7 +73,7 @@ auto to_json(
 template <typename OutputStreamType, typename SourceEncodingType, typename TargetEncodingType>
 auto to_json(
     rapidjson::Writer<OutputStreamType, SourceEncodingType, TargetEncodingType>& writer,
-    const char* const data) ->
+    const char* data) ->
     typename std::enable_if<std::is_same<
         char16_t, typename rapidjson::Writer<
                       OutputStreamType, SourceEncodingType, TargetEncodingType>::Ch>::value>::type;
@@ -78,7 +81,7 @@ auto to_json(
 template <typename OutputStreamType, typename SourceEncodingType, typename TargetEncodingType>
 auto to_json(
     rapidjson::Writer<OutputStreamType, SourceEncodingType, TargetEncodingType>& writer,
-    const char* const data) ->
+    const char* data) ->
     typename std::enable_if<std::is_same<
         char32_t, typename rapidjson::Writer<
                       OutputStreamType, SourceEncodingType, TargetEncodingType>::Ch>::value>::type;
@@ -149,6 +152,7 @@ void to_json(
     const std::filesystem::path& path);
 
 #endif
+} // namespace detail
 } // namespace serializer
 
 namespace deserializer

--- a/source/json_fwd.h
+++ b/source/json_fwd.h
@@ -153,6 +153,8 @@ void to_json(
 
 namespace deserializer
 {
+namespace detail
+{
 template <typename ContainerType, typename EncodingType, typename AllocatorType>
 auto from_json(
     const rapidjson::GenericValue<EncodingType, AllocatorType>& json_value,
@@ -182,5 +184,6 @@ auto from_json(
     ContainerType& container) ->
     typename std::enable_if<future_std::conjunction<
         traits::has_emplace<ContainerType>, traits::treat_as_object<ContainerType>>::value>::type;
+} // namespace detail
 } // namespace deserializer
 } // namespace json_utils

--- a/source/json_utils.h
+++ b/source/json_utils.h
@@ -11,9 +11,7 @@ template <typename WriterType, typename DataType, typename BufferType>
 const typename BufferType::Ch*
 serialize(BufferType& buffer, WriterType& writer, const DataType& data)
 {
-    using serializer::to_json;
-    to_json(writer, data);
-
+    serializer::to_json(writer, data);
     return buffer.GetString();
 }
 } // namespace detail
@@ -54,10 +52,6 @@ JSON_UTILS_NODISCARD ContainerType deserialize_from_json(const char* const json)
         "The container must have a default constructible.");
 
     ContainerType container;
-
-    // using deserializer::from_json;
-    // from_json(document, container);
-
     deserializer::from_json(document, container);
 
     return container;

--- a/source/json_utils.h
+++ b/source/json_utils.h
@@ -55,8 +55,10 @@ JSON_UTILS_NODISCARD ContainerType deserialize_from_json(const char* const json)
 
     ContainerType container;
 
-    using deserializer::from_json;
-    from_json(document, container);
+    // using deserializer::from_json;
+    // from_json(document, container);
+
+    deserializer::from_json(document, container);
 
     return container;
 }

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -176,8 +176,7 @@ void to_json(
     writer.StartObject();
 
     writer.Key("Inner Widget");
-    using json_utils::serializer::to_json;
-    to_json(writer, widget.get_inner_widget());
+    json_utils::serializer::to_json(writer, widget.get_inner_widget());
 
     writer.EndObject();
 }
@@ -247,8 +246,7 @@ void to_json(
     writer.String(widget.get_timestamp().c_str());
 
     writer.Key("Data");
-    using json_utils::serializer::to_json;
-    to_json(writer, widget.get_data());
+    json_utils::serializer::to_json(writer, widget.get_data());
 
     writer.EndObject();
 }
@@ -275,8 +273,7 @@ void from_json(
     }
 
     std::vector<std::string> data;
-    using json_utils::deserializer::from_json;
-    from_json(data_iterator->value, data);
+    json_utils::deserializer::from_json(data_iterator->value, data);
 
     widget.set_data(std::move(data));
 }

--- a/tests/unit_tests.cpp
+++ b/tests/unit_tests.cpp
@@ -99,7 +99,10 @@ void to_json(
     writer.EndObject();
 }
 
-void from_json(const rapidjson::Document& document, sample::simple_widget& widget)
+template <typename EncodingType, typename AllocatorType>
+void from_json(
+    const rapidjson::GenericValue<EncodingType, AllocatorType>& document,
+    sample::simple_widget& widget)
 {
     if (!document.IsObject()) {
         return;
@@ -179,7 +182,10 @@ void to_json(
     writer.EndObject();
 }
 
-void from_json(const rapidjson::Document& document, sample::composite_widget& widget)
+template <typename EncodingType, typename AllocatorType>
+void from_json(
+    const rapidjson::GenericValue<EncodingType, AllocatorType>& document,
+    sample::composite_widget& widget)
 {
     if (!document.IsObject()) {
         return;
@@ -191,9 +197,7 @@ void from_json(const rapidjson::Document& document, sample::composite_widget& wi
     }
 
     sample::simple_widget simple_widget;
-
-    using json_utils::deserializer::from_json;
-    from_json(*member_iterator, simple_widget);
+    json_utils::deserializer::from_json(*member_iterator, simple_widget);
 
     widget.set_inner_widget(std::move(simple_widget));
 }
@@ -249,7 +253,10 @@ void to_json(
     writer.EndObject();
 }
 
-void from_json(const rapidjson::Document& document, sample::heterogeneous_widget& widget)
+template <typename EncodingType, typename AllocatorType>
+void from_json(
+    const rapidjson::GenericValue<EncodingType, AllocatorType>& document,
+    sample::heterogeneous_widget& widget)
 {
     if (!document.IsObject()) {
         return;
@@ -423,7 +430,6 @@ TEST_CASE("Serialization of std::map<...>", "[Standard Containers]")
 
         // @note The exact serialization appears to depend on the STL implementation;
         // i.e., libc appears to enumerate the values in the reverse order used by MSVC.
-        // uses.
 
         REQUIRE(json.find("\"key_one\":1") != std::string::npos);
         REQUIRE(json.find("\"key_two\":2") != std::string::npos);


### PR DESCRIPTION
+ This change is inspired by Eric Niebler's [Suggested Design for Customization Points](http://ericniebler.github.io/std/wg21/D4381.html).
+ It has the advantage of avoiding the [ADL two-step](http://ericniebler.com/2014/10/21/customization-point-design-in-c11-and-beyond/) for anyone writing custom serialization/deserialization logic.